### PR TITLE
Raise the flit-core limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "flit_core.buildapi"
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=2,<4"]
 
 [tool.flit.metadata]
 author = "Sander Teunissen"


### PR DESCRIPTION
flit-core is on version 3.9 now so I hope we can unpin this.